### PR TITLE
fix the loading effect

### DIFF
--- a/src/components/Meme.jsx
+++ b/src/components/Meme.jsx
@@ -6,44 +6,47 @@ function Meme() {
   const [meme, setMeme] = useState({
     topText: "I am the",
     bottomText: "Baddest Bitch!!",
-    randomImg: "./img/shrek-meme.jpg"
+    randomImg: "./img/shrek-meme.jpg",
   });
   const [allMemes, setAllMemes] = useState([]);
-  const [loading, setLoading] = useState(true)
-
+  const [loading, setLoading] = useState(true);
+  console.log(allMemes);
   const fetchImages = () => {
+    setLoading(true);
     return fetch("https://api.imgflip.com/get_memes")
       .then((res) => res.json())
       .then((data) => {
         setAllMemes(data.data.memes);
-        setLoading(false)
-      })
-       
-      
+        setLoading(false);
+      });
   };
 
   useEffect(() => {
-    fetchImages(); 
-  }, [loading]);
+    fetchImages();
+  }, []);
+
 
   // Generate random memes
   const randomMemeImg = () => {
-    setLoading(prevLoad => !prevLoad)
-    const randomNum = Math.floor(Math.random() * allMemes.length)
-    const url = allMemes[randomNum].url
-    setMeme(prevMeme => ({
-      ...prevMeme,
-      randomImg: url
-    }))
-  }
+    setLoading(true);
+    const randomNum = Math.floor(Math.random() * allMemes.length);
+    const url = allMemes[randomNum].url;
+    setTimeout(() => {
+      setMeme((prevMeme) => ({
+        ...prevMeme,
+        randomImg: url,
+      }));
+      setLoading(false);
+    }, 200);
+  };
 
   const handleInputChange = (event) => {
-    const { name, value } = event.target
-    setMeme(prevMeme => ({
+    const { name, value } = event.target;
+    setMeme((prevMeme) => ({
       ...prevMeme,
-      [name]: value
-    }))
-  }
+      [name]: value,
+    }));
+  };
 
   return (
     <section className="meme-container">
@@ -75,8 +78,12 @@ function Meme() {
         ) : (
           <div className="meme">
             <img src={meme.randomImg} alt="meme-img" />
-            <Draggable bounds="parent" defaultPosition={{x: -66, y: 0 }}><p className="top-text">{meme.topText}</p></Draggable>
-            <Draggable bounds="parent" defaultPosition={{x: -100, y: 0}}><p className="bottom-text">{meme.bottomText}</p></Draggable>
+            <Draggable bounds="parent" defaultPosition={{ x: -66, y: 0 }}>
+              <p className="top-text">{meme.topText}</p>
+            </Draggable>
+            <Draggable bounds="parent" defaultPosition={{ x: -100, y: 0 }}>
+              <p className="bottom-text">{meme.bottomText}</p>
+            </Draggable>
           </div>
         )}
       </div>


### PR DESCRIPTION

Fixes #5  by @tcrz  

## Description
Fixes the loading state, removes loading state as a dependency preventing the fetchImages function from running whenever the loading state changes

## Tests
UseEffect for fetching images is called only on mount. Loading state runs before image shows up

## Checklist
<!-- Put "x" in the brackets [ ] below to check the box. Like this: [x] -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53).
- [x] My code follows the established code style of the repository.
- [x] I run the project locally and verified that there are no
  visible errors.


## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
